### PR TITLE
refactor: abstract taskfile loading via loader interface

### DIFF
--- a/taskfile/loader.go
+++ b/taskfile/loader.go
@@ -1,0 +1,43 @@
+package taskfile
+
+import (
+        stdErrors "errors"
+
+        "gopkg.in/yaml.v3"
+
+        "github.com/go-task/task/v3/errors"
+        "github.com/go-task/task/v3/internal/filepathext"
+        "github.com/go-task/task/v3/taskfile/ast"
+)
+
+// Loader defines the behavior required to load a Taskfile from raw data.
+//
+// Note: the returned [ast.Taskfile] is still backed by YAML-specific
+// unmarshalling logic within the ast package. Loaders for alternative
+// formats must populate the AST structures directly without relying on the
+// YAML-only helpers. Future work will extract those bindings out of the ast
+// package so it becomes truly format agnostic.
+type Loader interface {
+        Load(data []byte, location string) (*ast.Taskfile, error)
+}
+
+// YAMLLoader implements [Loader] using YAML as the configuration format.
+type YAMLLoader struct{}
+
+// Load parses the given data as YAML into a Taskfile structure.
+func (YAMLLoader) Load(data []byte, location string) (*ast.Taskfile, error) {
+	var tf ast.Taskfile
+	if err := yaml.Unmarshal(data, &tf); err != nil {
+		taskfileDecodeErr := &errors.TaskfileDecodeError{}
+		if stdErrors.As(err, &taskfileDecodeErr) {
+			snippet := NewSnippet(data,
+				WithLine(taskfileDecodeErr.Line),
+				WithColumn(taskfileDecodeErr.Column),
+				WithPadding(2),
+			)
+			return nil, taskfileDecodeErr.WithFileInfo(location, snippet.String())
+		}
+		return nil, &errors.TaskfileInvalidError{URI: filepathext.TryAbsToRel(location), Err: err}
+	}
+	return &tf, nil
+}

--- a/taskfile/loader_test.go
+++ b/taskfile/loader_test.go
@@ -1,0 +1,23 @@
+package taskfile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/go-task/task/v3/taskfile/ast"
+)
+
+func TestYAMLLoader(t *testing.T) {
+	t.Parallel()
+
+	data := []byte("version: '3'\n\ntasks:\n  default:\n    cmds:\n      - echo hello\n")
+	loader := YAMLLoader{}
+	tf, err := loader.Load(data, "Taskfile.yml")
+	require.NoError(t, err)
+
+	var expected ast.Taskfile
+	require.NoError(t, yaml.Unmarshal(data, &expected))
+	require.Equal(t, &expected, tf)
+}

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/dominikbraun/graph"
 	"golang.org/x/sync/errgroup"
-	"gopkg.in/yaml.v3"
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/env"
-	"github.com/go-task/task/v3/internal/filepathext"
 	"github.com/go-task/task/v3/internal/templater"
 	"github.com/go-task/task/v3/taskfile/ast"
 )
@@ -40,6 +40,7 @@ type (
 	// [ast.TaskfileGraph] from them.
 	Reader struct {
 		graph               *ast.TaskfileGraph
+		loaders             map[string]Loader
 		insecure            bool
 		download            bool
 		offline             bool
@@ -55,7 +56,11 @@ type (
 // options.
 func NewReader(opts ...ReaderOption) *Reader {
 	r := &Reader{
-		graph:               ast.NewTaskfileGraph(),
+		graph: ast.NewTaskfileGraph(),
+		loaders: map[string]Loader{
+			".yml":  YAMLLoader{},
+			".yaml": YAMLLoader{},
+		},
 		insecure:            false,
 		download:            false,
 		offline:             false,
@@ -117,6 +122,24 @@ type offlineOption struct {
 
 func (o *offlineOption) ApplyToReader(r *Reader) {
 	r.offline = o.offline
+}
+
+// WithLoader registers a new [Loader] for the given file extension. If a loader
+// already exists for the extension, it will be replaced.
+func WithLoader(ext string, loader Loader) ReaderOption {
+	return &loaderOption{ext: strings.ToLower(ext), loader: loader}
+}
+
+type loaderOption struct {
+	ext    string
+	loader Loader
+}
+
+func (o *loaderOption) ApplyToReader(r *Reader) {
+	if r.loaders == nil {
+		r.loaders = map[string]Loader{}
+	}
+	r.loaders[o.ext] = o.loader
 }
 
 // WithTempDir sets the temporary directory that will be used by the [Reader].
@@ -324,19 +347,16 @@ func (r *Reader) readNode(ctx context.Context, node Node) (*ast.Taskfile, error)
 		return nil, err
 	}
 
-	var tf ast.Taskfile
-	if err := yaml.Unmarshal(b, &tf); err != nil {
-		// Decode the taskfile and add the file info the any errors
-		taskfileDecodeErr := &errors.TaskfileDecodeError{}
-		if errors.As(err, &taskfileDecodeErr) {
-			snippet := NewSnippet(b,
-				WithLine(taskfileDecodeErr.Line),
-				WithColumn(taskfileDecodeErr.Column),
-				WithPadding(2),
-			)
-			return nil, taskfileDecodeErr.WithFileInfo(node.Location(), snippet.String())
-		}
-		return nil, &errors.TaskfileInvalidError{URI: filepathext.TryAbsToRel(node.Location()), Err: err}
+	ext := strings.ToLower(filepath.Ext(node.Location()))
+	loader, ok := r.loaders[ext]
+	if !ok {
+		// Fallback to YAML loader if no loader is registered for the extension
+		loader = YAMLLoader{}
+	}
+
+	tf, err := loader.Load(b, node.Location())
+	if err != nil {
+		return nil, err
 	}
 
 	// Check that the Taskfile is set and has a schema version
@@ -357,7 +377,7 @@ func (r *Reader) readNode(ctx context.Context, node Node) (*ast.Taskfile, error)
 		}
 	}
 
-	return &tf, nil
+	return tf, nil
 }
 
 func (r *Reader) readNodeContent(ctx context.Context, node Node) ([]byte, error) {


### PR DESCRIPTION
## Summary
- introduce Loader interface and YAMLLoader implementation
- allow registering loaders by extension and default to YAML
- use registered loader in reader and add unit test for YAMLLoader
- document that ast Taskfile parsing still relies on YAML-specific logic

## Testing
- `go test ./...`

## Prompt 

Task 1: Refactor Configuration Loading (Abstract YAML Parsing)

Purpose: Prepare the codebase to handle multiple config file formats (YAML and HCL) by abstracting the parsing logic. Currently, the Taskfile loading is tightly coupled to YAML via built-in UnmarshalYAML methods. We need to introduce a format-agnostic layer so that adding HCL becomes straightforward.
	•	Implementation:
	•	Identify where Taskfiles are read and parsed (e.g. functions that search for Taskfile.yml and call YAML unmarshal). Refactor this logic to use a config loader interface or strategy pattern. For example, define an interface TaskfileLoader with a method like LoadTaskfile(path) (*Taskfile, error).
	•	Provide two implementations: YAMLLoader (uses existing YAML unmarshal logic) and HCLLoader (to be implemented in later tasks). Determine format by file extension or content.
	•	Decouple YAML-specific code: If Taskfile.UnmarshalYAML and other struct methods exist, consider moving YAML-specific unmarshalling into the YAML loader. The core Taskfile struct should not assume YAML input.
	•	Ensure that all references to YAML in the loading process (e.g. error messages like “invalid YAML”) are either generalized or moved into the YAML loader. This lays the groundwork for adding HCL seamlessly.
	•	Validation:
	•	All existing tests for loading and parsing YAML Taskfiles must continue to pass. For example, running task with a standard Taskfile.yml should behave exactly as before.
	•	Add a unit test for the loader interface: invoke the YAML loader on a known-good Taskfile YAML content and verify it returns a proper Taskfile struct (same as direct unmarshal). This confirms the refactor didn’t break YAML support.

------
https://chatgpt.com/codex/tasks/task_e_6891f2a02d888330bc1cd199e30270bb