### PR TITLE
feat: inject task references and update HCL syntax

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -47,7 +47,7 @@ func (c *Compiler) FastGetVariables(t *ast.Task, call *Call) (*ast.Vars, error) 
 
 func (c *Compiler) getVariables(t *ast.Task, call *Call, evaluateShVars bool) (*ast.Vars, error) {
 	result := env.GetEnviron()
-	evaluator := hclext.NewHCLEvaluator(result, result, nil)
+	evaluator := hclext.NewHCLEvaluator(result, result, nil, nil)
 	hasHCL := false
 	specialVars, err := c.getSpecialVars(t, call)
 	if err != nil {
@@ -146,7 +146,7 @@ func (c *Compiler) getVariables(t *ast.Task, call *Call, evaluateShVars bool) (*
 	}
 
 	if hasHCL {
-		resVars, resEnv, err := hclext.NewResolver(result, result, nil).Resolve()
+		resVars, resEnv, err := hclext.NewResolver(result, result, nil, nil).Resolve()
 		if err != nil {
 			return nil, err
 		}

--- a/hcl_e2e_test.go
+++ b/hcl_e2e_test.go
@@ -41,4 +41,17 @@ func TestHCLE2E(t *testing.T) {
 	if !strings.Contains(output, "PLATFORM=linux") {
 		t.Fatalf("missing platform output: %s", output)
 	}
+
+	cmd = exec.Command("go", "run", "./cmd/task", "-t", filepath.Join("testdata", "HCLE2ETest", "Taskfile.hcl"), "scoped")
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("task run failed: %v\n%s", err, out)
+	}
+	scoped := string(out)
+	if !strings.Contains(scoped, "TEST") {
+		t.Fatalf("missing test output: %s", scoped)
+	}
+	if !strings.Contains(scoped, "DELAYED") {
+		t.Fatalf("missing delayed output: %s", scoped)
+	}
 }

--- a/internal/hclext/diagnostics_test.go
+++ b/internal/hclext/diagnostics_test.go
@@ -16,7 +16,7 @@ func TestUnsupportedTupleErrorIncludesRange(t *testing.T) {
 	require.False(t, diags.HasErrors())
 	vars := ast.NewVars()
 	vars.Set("INVALID", ast.Var{Expr: expr})
-	r := NewResolver(vars, nil, nil)
+	r := NewResolver(vars, nil, nil, nil)
 	_, _, err := r.Resolve()
 	require.Error(t, err)
 	rng := expr.Range()

--- a/internal/hclext/evaluator.go
+++ b/internal/hclext/evaluator.go
@@ -23,7 +23,7 @@ type HCLEvaluator struct {
 	env     map[string]cty.Value
 }
 
-func NewHCLEvaluator(vars, env *ast.Vars, runner TaskRunner) *HCLEvaluator {
+func NewHCLEvaluator(vars, env *ast.Vars, runner TaskRunner, tasks *ast.Tasks) *HCLEvaluator {
 	varVals := map[string]cty.Value{}
 	if vars != nil {
 		for k, v := range vars.All() {
@@ -40,11 +40,23 @@ func NewHCLEvaluator(vars, env *ast.Vars, runner TaskRunner) *HCLEvaluator {
 			}
 		}
 	}
+	taskVals := map[string]cty.Value{}
+	if tasks != nil {
+		for name := range tasks.Keys(nil) {
+			taskVals[name] = cty.StringVal(name)
+		}
+	}
+
+	varsMap := map[string]cty.Value{
+		"vars": cty.ObjectVal(varVals),
+		"env":  cty.ObjectVal(envVals),
+	}
+	if len(taskVals) > 0 {
+		varsMap["task"] = cty.ObjectVal(taskVals)
+	}
+
 	ctx := &hcl.EvalContext{
-		Variables: map[string]cty.Value{
-			"vars": cty.ObjectVal(varVals),
-			"env":  cty.ObjectVal(envVals),
-		},
+		Variables: varsMap,
 		Functions: builtinFunctions(runner),
 	}
 	return &HCLEvaluator{EvalCtx: ctx, vars: varVals, env: envVals}
@@ -60,7 +72,7 @@ func builtinFunctions(runner TaskRunner) map[string]function.Function {
 	funcs["tuple"] = tupleFunc()
 
 	if runner != nil {
-		funcs["task"] = taskFunc(runner)
+		funcs["exec"] = execFunc(runner)
 	}
 	return funcs
 }
@@ -230,9 +242,9 @@ func shellFunc(shell string) function.Function {
 	})
 }
 
-func taskFunc(runner TaskRunner) function.Function {
+func execFunc(runner TaskRunner) function.Function {
 	return function.New(&function.Spec{
-		Params:   []function.Parameter{{Name: "name", Type: cty.String}},
+		Params:   []function.Parameter{{Name: "task", Type: cty.String}},
 		VarParam: &function.Parameter{Name: "vars", Type: cty.DynamicPseudoType},
 		Type:     function.StaticReturnType(cty.String),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {

--- a/internal/hclext/resolve.go
+++ b/internal/hclext/resolve.go
@@ -15,6 +15,7 @@ type Resolver struct {
 	vars     *ast.Vars
 	env      *ast.Vars
 	runner   TaskRunner
+	tasks    *ast.Tasks
 	varCache map[string]any
 	envCache map[string]any
 	varStack map[string]bool
@@ -22,11 +23,12 @@ type Resolver struct {
 }
 
 // NewResolver creates a new Resolver.
-func NewResolver(vars, env *ast.Vars, runner TaskRunner) *Resolver {
+func NewResolver(vars, env *ast.Vars, runner TaskRunner, tasks *ast.Tasks) *Resolver {
 	r := &Resolver{
 		vars:     vars,
 		env:      env,
 		runner:   runner,
+		tasks:    tasks,
 		varCache: map[string]any{},
 		envCache: map[string]any{},
 		varStack: map[string]bool{},
@@ -115,7 +117,7 @@ func (r *Resolver) resolveVar(name string) (any, error) {
 			return nil, err
 		}
 	}
-	eval := NewHCLEvaluator(varsFromCache(r.varCache), envFromCache(r.envCache), r.runner)
+	eval := NewHCLEvaluator(varsFromCache(r.varCache), envFromCache(r.envCache), r.runner, r.tasks)
 	val, err := eval.EvalValue(v.Expr)
 	if err != nil {
 		return nil, err
@@ -150,7 +152,7 @@ func (r *Resolver) resolveEnv(name string) (any, error) {
 					return nil, err
 				}
 			}
-			eval := NewHCLEvaluator(varsFromCache(r.varCache), envFromCache(r.envCache), r.runner)
+			eval := NewHCLEvaluator(varsFromCache(r.varCache), envFromCache(r.envCache), r.runner, r.tasks)
 			val, err := eval.EvalValue(v.Expr)
 			if err != nil {
 				return nil, err

--- a/task.go
+++ b/task.go
@@ -284,7 +284,7 @@ func (e *Executor) runDeferred(t *ast.Task, call *Call, i int, deferredExitCode 
 	vars, _ := e.Compiler.GetVariables(origTask, call)
 	cache := &templater.Cache{Vars: vars}
 	runtimeEnv := env.GetEnviron()
-	hclEval := hclext.NewHCLEvaluator(vars, runtimeEnv, e.callTask)
+	hclEval := hclext.NewHCLEvaluator(vars, runtimeEnv, e.callTask, e.Taskfile.Tasks)
 	extra := map[string]any{}
 
 	if deferredExitCode != nil && *deferredExitCode > 0 {

--- a/taskfile/hcl_evaluator_test.go
+++ b/taskfile/hcl_evaluator_test.go
@@ -16,7 +16,7 @@ func TestHCLEvaluatorExpressions(t *testing.T) {
 	t.Setenv("HOME", "/home/test")
 	vars := ast.NewVars()
 	vars.Set("FOO", ast.Var{Value: "bar"})
-	eval := hclext.NewHCLEvaluator(vars, env.GetEnviron(), nil)
+	eval := hclext.NewHCLEvaluator(vars, env.GetEnviron(), nil, nil)
 
 	expr1, diags := hclsyntax.ParseTemplate([]byte("${vars.FOO}"), "test.hcl", hcl.InitialPos)
 	require.False(t, diags.HasErrors())

--- a/taskfile/hcl_loader_test.go
+++ b/taskfile/hcl_loader_test.go
@@ -70,3 +70,28 @@ func TestHCLLoaderRejectsGoTemplates(t *testing.T) {
 	_, err := loader.Load(data, "Taskfile.hcl")
 	require.Error(t, err)
 }
+
+func TestTaskReferences(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`version = "3"
+        task "a" {
+            cmds = ["echo A"]
+        }
+        task "b" {
+            deps = [ task.a ]
+            cmds = [ exec(task.a) ]
+        }
+    `)
+
+	loader := HCLLoader{}
+	tf, err := loader.Load(data, "Taskfile.hcl")
+	require.NoError(t, err)
+
+	b, ok := tf.Tasks.Get("b")
+	require.True(t, ok)
+	require.Len(t, b.Deps, 1)
+	require.Equal(t, "a", b.Deps[0].Task)
+	require.Len(t, b.Cmds, 1)
+	require.NotNil(t, b.Cmds[0].Expr)
+}

--- a/taskfile/hcl_recursive_vars_test.go
+++ b/taskfile/hcl_recursive_vars_test.go
@@ -25,7 +25,7 @@ func TestRecursiveVars(t *testing.T) {
 	vars.Set("NAME", ast.Var{Expr: parseExpr(t, `"BOB"`)})
 	vars.Set("UPPER_GREETING", ast.Var{Expr: parseExpr(t, `upper(vars.GREETING)`)})
 
-	resolver := hclext.NewResolver(vars, env.GetEnviron(), nil)
+	resolver := hclext.NewResolver(vars, env.GetEnviron(), nil, nil)
 	resolved, _, err := resolver.Resolve()
 	require.NoError(t, err)
 
@@ -41,7 +41,7 @@ func TestOrderIndependence(t *testing.T) {
 	vars.Set("INTERMEDIATE", ast.Var{Expr: parseExpr(t, `"${vars.BASE} + ok"`)})
 	vars.Set("BASE", ast.Var{Expr: parseExpr(t, `"yup"`)})
 
-	resolver := hclext.NewResolver(vars, env.GetEnviron(), nil)
+	resolver := hclext.NewResolver(vars, env.GetEnviron(), nil, nil)
 	resolved, _, err := resolver.Resolve()
 	require.NoError(t, err)
 
@@ -53,7 +53,7 @@ func TestCyclicReference(t *testing.T) {
 	vars := ast.NewVars()
 	vars.Set("LOOP", ast.Var{Expr: parseExpr(t, `"${vars.LOOP}"`)})
 
-	resolver := hclext.NewResolver(vars, env.GetEnviron(), nil)
+	resolver := hclext.NewResolver(vars, env.GetEnviron(), nil, nil)
 	_, _, err := resolver.Resolve()
 	require.Error(t, err)
 }

--- a/taskfile/hcl_runtime_test.go
+++ b/taskfile/hcl_runtime_test.go
@@ -22,7 +22,7 @@ func TestBlockSyntaxEnforced(t *testing.T) {
 }
 
 func TestShFunctionSuccess(t *testing.T) {
-	eval := hclext.NewHCLEvaluator(nil, env.GetEnviron(), nil)
+	eval := hclext.NewHCLEvaluator(nil, env.GetEnviron(), nil, nil)
 	expr, diags := hclsyntax.ParseExpression([]byte(`sh("echo hi")`), "test.hcl", hcl.InitialPos)
 	require.False(t, diags.HasErrors())
 	v, err := eval.EvalString(expr)
@@ -31,7 +31,7 @@ func TestShFunctionSuccess(t *testing.T) {
 }
 
 func TestShFunctionFail(t *testing.T) {
-	eval := hclext.NewHCLEvaluator(nil, env.GetEnviron(), nil)
+	eval := hclext.NewHCLEvaluator(nil, env.GetEnviron(), nil, nil)
 	expr, diags := hclsyntax.ParseExpression([]byte(`sh("exit 1")`), "test.hcl", hcl.InitialPos)
 	require.False(t, diags.HasErrors())
 	_, err := eval.EvalString(expr)
@@ -42,8 +42,10 @@ func TestTaskFunctionStdoutCapture(t *testing.T) {
 	runner := func(name string, vars *ast.Vars) (string, error) {
 		return "output", nil
 	}
-	eval := hclext.NewHCLEvaluator(nil, env.GetEnviron(), runner)
-	expr, diags := hclsyntax.ParseExpression([]byte(`task("build")`), "test.hcl", hcl.InitialPos)
+	tasks := ast.NewTasks()
+	tasks.Set("build", &ast.Task{})
+	eval := hclext.NewHCLEvaluator(nil, env.GetEnviron(), runner, tasks)
+	expr, diags := hclsyntax.ParseExpression([]byte(`exec(task.build)`), "test.hcl", hcl.InitialPos)
 	require.False(t, diags.HasErrors())
 	v, err := eval.EvalString(expr)
 	require.NoError(t, err)
@@ -51,9 +53,20 @@ func TestTaskFunctionStdoutCapture(t *testing.T) {
 }
 
 func TestInvalidReference(t *testing.T) {
-	eval := hclext.NewHCLEvaluator(ast.NewVars(), env.GetEnviron(), nil)
+	eval := hclext.NewHCLEvaluator(ast.NewVars(), env.GetEnviron(), nil, nil)
 	expr, diags := hclsyntax.ParseExpression([]byte(`FOO`), "test.hcl", hcl.InitialPos)
 	require.False(t, diags.HasErrors())
 	_, err := eval.EvalString(expr)
 	require.Error(t, err)
+}
+
+func TestInvalidTaskReference(t *testing.T) {
+	tasks := ast.NewTasks()
+	tasks.Set("known", &ast.Task{})
+	eval := hclext.NewHCLEvaluator(ast.NewVars(), env.GetEnviron(), nil, tasks)
+	expr, diags := hclsyntax.ParseExpression([]byte(`task.unknown`), "test.hcl", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+	_, err := eval.EvalString(expr)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "test.hcl")
 }

--- a/taskfile/loader_hcl.go
+++ b/taskfile/loader_hcl.go
@@ -219,26 +219,54 @@ func parseDeps(expr hcl.Expression, location string) ([]*ast.Dep, error) {
 	}
 	deps := make([]*ast.Dep, 0, len(tuple.Exprs))
 	for _, e := range tuple.Exprs {
-		call, ok := e.(*hclsyntax.FunctionCallExpr)
-		if !ok || call.Name != "task" || len(call.Args) == 0 {
+		switch expr := e.(type) {
+		case *hclsyntax.ScopeTraversalExpr:
+			name, ok := taskTraversalName(expr)
+			if !ok {
+				return nil, &errors.TaskfileInvalidError{URI: filepathext.TryAbsToRel(location), Err: hcl.Diagnostics{}}
+			}
+			deps = append(deps, &ast.Dep{Task: name})
+		case *hclsyntax.FunctionCallExpr:
+			if expr.Name != "exec" || len(expr.Args) == 0 {
+				return nil, &errors.TaskfileInvalidError{URI: filepathext.TryAbsToRel(location), Err: hcl.Diagnostics{}}
+			}
+			tExpr, ok := expr.Args[0].(*hclsyntax.ScopeTraversalExpr)
+			if !ok {
+				return nil, &errors.TaskfileInvalidError{URI: filepathext.TryAbsToRel(location), Err: hcl.Diagnostics{}}
+			}
+			name, ok := taskTraversalName(tExpr)
+			if !ok {
+				return nil, &errors.TaskfileInvalidError{URI: filepathext.TryAbsToRel(location), Err: hcl.Diagnostics{}}
+			}
+			dep := &ast.Dep{Task: name}
+			if len(expr.Args) > 1 {
+				vars, err := parseVarsExpr(expr.Args[1], location)
+				if err != nil {
+					return nil, err
+				}
+				dep.Vars = vars
+			}
+			deps = append(deps, dep)
+		default:
 			return nil, &errors.TaskfileInvalidError{URI: filepathext.TryAbsToRel(location), Err: hcl.Diagnostics{}}
 		}
-		var name string
-		diags := gohcl.DecodeExpression(call.Args[0], nil, &name)
-		if diags.HasErrors() {
-			return nil, &errors.TaskfileInvalidError{URI: filepathext.TryAbsToRel(location), Err: diags}
-		}
-		dep := &ast.Dep{Task: name}
-		if len(call.Args) > 1 {
-			vars, err := parseVarsExpr(call.Args[1], location)
-			if err != nil {
-				return nil, err
-			}
-			dep.Vars = vars
-		}
-		deps = append(deps, dep)
 	}
 	return deps, nil
+}
+
+func taskTraversalName(expr *hclsyntax.ScopeTraversalExpr) (string, bool) {
+	if len(expr.Traversal) != 2 {
+		return "", false
+	}
+	root, ok := expr.Traversal[0].(hcl.TraverseRoot)
+	if !ok || root.Name != "task" {
+		return "", false
+	}
+	attr, ok := expr.Traversal[1].(hcl.TraverseAttr)
+	if !ok {
+		return "", false
+	}
+	return attr.Name, true
 }
 
 func objectKey(expr hcl.Expression) (string, hcl.Diagnostics) {

--- a/testdata/HCLE2ETest/Taskfile.hcl
+++ b/testdata/HCLE2ETest/Taskfile.hcl
@@ -26,13 +26,15 @@ task "build" {
 }
 
 task "lint" {
+  vars { MODE = "fast" }
   cmds = ["echo LINT MODE ${vars.MODE}", "echo TWO-DONE"]
 }
 
 task "all" {
   deps = [
-    task("build"),
-    task("lint", {MODE = "fast"})
+    task.build,
+    task.lint,
+    task.scoped,
   ]
   cmds = [
     "echo FINAL ${vars.ORIGINAL}",
@@ -40,5 +42,25 @@ task "all" {
     "echo GREET=${vars.UPPER_GREETING}",
     "echo EXT=${env.EXTENDED}",
     "echo PLATFORM=${vars.SUPPORTED_PLATFORMS[0]}"
+  ]
+}
+
+task "test" {
+  cmds = ["echo 'echo TEST'"]
+}
+
+task "delayed" {
+  vars { MSG = "" }
+  cmds = ["echo 'echo DELAYED ${vars.MSG}'"]
+}
+
+task "scoped" {
+  deps = [
+    task.test,
+    task.delayed,
+  ]
+  cmds = [
+    exec(task.test),
+    exec(task.delayed, { MSG = "DELAYED" }),
   ]
 }

--- a/variables.go
+++ b/variables.go
@@ -114,7 +114,7 @@ func (e *Executor) compiledTask(call *Call, evaluateShVars bool) (*ast.Task, err
 		envDefs.Merge(e.Taskfile.Env, nil)
 		envDefs.Merge(templater.ReplaceVars(dotenvEnvs, cache), nil)
 		envDefs.Merge(origTask.Env, nil)
-		resolver := hclext.NewResolver(vars, envDefs, e.callTask)
+		resolver := hclext.NewResolver(vars, envDefs, e.callTask, e.Taskfile.Tasks)
 		_, resolvedEnv, err := resolver.Resolve()
 		if err != nil {
 			return nil, err
@@ -142,7 +142,7 @@ func (e *Executor) compiledTask(call *Call, evaluateShVars bool) (*ast.Task, err
 
 	runtimeEnv := env.GetEnviron()
 	runtimeEnv.Merge(new.Env, nil)
-	hclEval := hclext.NewHCLEvaluator(vars, runtimeEnv, e.callTask)
+	hclEval := hclext.NewHCLEvaluator(vars, runtimeEnv, e.callTask, e.Taskfile.Tasks)
 
 	if len(origTask.Sources) > 0 && origTask.Method != "none" {
 		var checker fingerprint.SourcesCheckable


### PR DESCRIPTION
## Summary
- inject defined tasks into HCL evaluation context
- replace task("name") calls with task.<name> references and exec function
- test task references in deps and cmds including invalid references

## Testing
- `go test ./...`

## Prompt 

### Task 12: Injected Task References

**Purpose:**
Support direct use of defined tasks as variable-like references inside expressions or function calls, replacing the previous `task("...")` function syntax with native injected task references.

---

**Requirements:**
- All defined tasks must be injected into the evaluation context as top-level variables using their name.
- Referencing `task.test` inside expressions or interpolations must resolve to a Task reference object.
- Only top-level tasks should be injected; no support for substructures or introspection yet.
- The previous `task("name")` function must be removed or deprecated in favor of direct references.

---

**Example:**
```hcl
task "scoped" {
  deps = [
    task.test,
    task.delayed,
  ]

  cmds = [
    exec(task.test),
    exec(task.delayed, {
      DATE3 = sh("date")
    }),
  ]
}
```

---

**Implementation Hints (Do Not Copy Code):**
- During parsing, all task blocks should be registered into a global context map.
- That map is injected as variables into the evaluation context (e.g. `EvalContext`).
- A synthetic `cty.ObjectVal` (or similar) may be needed to support `task.<name>` resolution.
- Errors should occur if undefined tasks are referenced.

---

**Validation:**
- Add test case for a task referencing another via `task.<name>` in both `deps` and `cmds`.
- Ensure fallback to `task("name")` is removed.
- Invalid usage like `task.unknown` should return a proper error message with file/line context.
- Add scenario to `HCLE2ETest` with a task that uses two others as dependencies and references them inside exec.

------
https://chatgpt.com/codex/tasks/task_e_68925996cff08330a85d203a67b21ec5